### PR TITLE
Add FastAPI server implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+__pycache__/
 .env

--- a/fastapi_server.py
+++ b/fastapi_server.py
@@ -1,0 +1,108 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+import httpx
+import os
+from dotenv import load_dotenv
+from typing import List, Dict, Any
+import openai
+
+load_dotenv()
+
+app = FastAPI()
+
+class ChatRequest(BaseModel):
+    message: str
+
+async def search_cargurus(query: str) -> List[Dict[str, Any]]:
+    api_key = os.getenv("CARGURUS_API_KEY")
+    if not api_key:
+        return []
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                "https://api.cargurus.com/v1/listings",
+                params={"query": query, "api_key": api_key},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("results", [])
+    except Exception as e:
+        print("Cargurus error", e)
+        return []
+
+async def search_carfax(query: str) -> List[Dict[str, Any]]:
+    api_key = os.getenv("CARFAX_API_KEY")
+    if not api_key:
+        return []
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                "https://api.carfax.com/v1/cars",
+                params={"query": query, "api_key": api_key},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("listings", [])
+    except Exception as e:
+        print("Carfax error", e)
+        return []
+
+async def search_carsdotcom(query: str) -> List[Dict[str, Any]]:
+    api_key = os.getenv("CARSDOTCOM_API_KEY")
+    if not api_key:
+        return []
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                "https://api.cars.com/v1/search",
+                params={"query": query, "api_key": api_key},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("vehicles", [])
+    except Exception as e:
+        print("Cars.com error", e)
+        return []
+
+async def search_all_sources(query: str) -> List[Dict[str, Any]]:
+    import asyncio
+    results = await asyncio.gather(
+        search_cargurus(query),
+        search_carfax(query),
+        search_carsdotcom(query),
+    )
+    cars: List[Dict[str, Any]] = []
+    for r in results:
+        cars.extend(r)
+    return cars
+
+@app.post("/api/chat")
+async def chat(req: ChatRequest):
+    message = req.message
+    try:
+        client = openai.AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        completion = await client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": message}],
+        )
+        reply = completion.choices[0].message.content
+        if "find cars" in message.lower():
+            query = message.lower().replace("find cars", "").strip()
+            cars = await search_all_sources(query)
+            return {"reply": reply, "cars": cars}
+        return {"reply": reply}
+    except Exception as e:
+        print(e)
+        raise HTTPException(status_code=500, detail="Error processing request")
+
+app.mount("/", StaticFiles(directory="public", html=True), name="static")
+
+
+if __name__ == "__main__":
+    import uvicorn
+    port = int(os.getenv("PORT", 8000))
+    uvicorn.run("fastapi_server:app", host="0.0.0.0", port=port)

--- a/fastapi_server.py
+++ b/fastapi_server.py
@@ -95,7 +95,7 @@ async def chat(req: ChatRequest):
         return {"reply": reply}
     except Exception as e:
         print(e)
-        raise HTTPException(status_code=500, detail="Error processing request")
+        raise HTTPException(status_code=500, detail="Error processing request") from e
 
 app.mount("/", StaticFiles(directory="public", html=True), name="static")
 

--- a/fastapi_server.py
+++ b/fastapi_server.py
@@ -28,7 +28,7 @@ async def search_cargurus(query: str) -> List[Dict[str, Any]]:
             data = resp.json()
             return data.get("results", [])
     except Exception as e:
-        print("Cargurus error", e)
+        logging.error("Cargurus error: %s", e)
         return []
 
 async def search_carfax(query: str) -> List[Dict[str, Any]]:

--- a/fastapi_server.py
+++ b/fastapi_server.py
@@ -68,7 +68,6 @@ async def search_carsdotcom(query: str) -> List[Dict[str, Any]]:
         return []
 
 async def search_all_sources(query: str) -> List[Dict[str, Any]]:
-    import asyncio
     results = await asyncio.gather(
         search_cargurus(query),
         search_carfax(query),

--- a/fastapi_server.py
+++ b/fastapi_server.py
@@ -19,12 +19,11 @@ async def search_cargurus(query: str) -> List[Dict[str, Any]]:
     if not api_key:
         return []
     try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                "https://api.cargurus.com/v1/listings",
-                params={"query": query, "api_key": api_key},
-                timeout=10,
-            )
+        resp = await shared_client.get(
+            "https://api.cargurus.com/v1/listings",
+            params={"query": query, "api_key": api_key},
+            timeout=10,
+        )
             resp.raise_for_status()
             data = resp.json()
             return data.get("results", [])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+httpx
+python-dotenv
+openai


### PR DESCRIPTION
## Summary
- add FastAPI-based server implementation
- add Python requirements
- update `.gitignore`

## Testing
- `python3 -m pip install --user -r requirements.txt`
- `PORT=8001 python3 fastapi_server.py & sleep 3; curl -I http://127.0.0.1:8001/ | head -n 1; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_686b6c1aa49483239eae5d5f831649b0

## Summary by Sourcery

Add a FastAPI-based server implementation with chat and car search capabilities, static file serving, and a requirements file for dependencies

New Features:
- Introduce FastAPI server with a /api/chat endpoint that interfaces with OpenAI for chat completions
- Add asynchronous car search integration across CarGurus, Carfax, and Cars.com APIs when prompts include "find cars"
- Serve static frontend content from a public directory

Enhancements:
- Add requirements.txt to define Python dependencies for FastAPI, Uvicorn, HTTPX, python-dotenv, and OpenAI

Chores:
- Initialize .gitignore to exclude environment and runtime files